### PR TITLE
Merge back danwashusen's fork

### DIFF
--- a/commands/instructions.js
+++ b/commands/instructions.js
@@ -7,3 +7,14 @@ console.log('  * Double click on rootCA.pem');
 console.log('  * Keychain should open, find the certificate called "Dev Cert Authority", double click it');
 console.log('  * Expand `trust` and change "When using this certificate" to "always trust"');
 console.log('  * Close window and authorize with your system password if required');
+console.log('');
+console.log('Ubuntu:');
+console.log('  * Open ~/.dev-cert-authority in Terminal');
+console.log('  * Convert the rootCA.pem file to a CRT file');
+console.log('      $ openssl x509 -in rootCA.pem -inform PEM -out rootCA.crt');
+console.log('  * Add the rootCA.crt file to the list of CA certificates');
+console.log('      $ sudo ln -s ~/.dev-cert-authority/rootCA.crt /usr/share/ca-certificates/dev-rootCA.crt');
+console.log('  * Update the CA list');
+console.log('      $ sudo update-ca-certificates');
+
+

--- a/paths.js
+++ b/paths.js
@@ -25,7 +25,8 @@ Paths.makeCertPaths = function (host) {
   return {
     key: `${Paths.hostsDir}/${host}.key`,
     csr: `${Paths.hostsDir}/${host}.csr`,
-    crt: `${Paths.hostsDir}/${host}.crt`
+    crt: `${Paths.hostsDir}/${host}.crt`,
+    ext: `${Paths.hostsDir}/${host}.ext`
   };
 };
 

--- a/sign-cert.js
+++ b/sign-cert.js
@@ -9,15 +9,24 @@ const AppPaths = require('./paths');
 const Log = require('./log');
 
 function ext(host) {
-  return `
+  var result = `
     authorityKeyIdentifier=keyid,issuer
     basicConstraints=CA:FALSE
     keyUsage=digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
     subjectAltName=@alt_names
 
     [alt_names]
-    DNS.1=${host}
-  `;
+    DNS.1=${host}`;
+  
+  // if the user is requesting a wildcarded certificate add the root as well
+  if (host != null && host.startsWith("*.")) {
+    hostNoWildcard = host.substring(2);
+    result = `
+      ${result}
+      DNS.2=${hostNoWildcard}`;
+  }
+
+  return result;
 }
 
 module.exports = function (host) {


### PR DESCRIPTION
This PR addresses #5 by merging @danwashusen 's fork back, up to commit https://github.com/danwashusen/dev-cert-authority/commit/48a1b19111f20fdb78c8e4df5f660ad0fd1500dd so the readme install instruction stays with npm as source.

Note that @apkrasny 's fix https://github.com/danwashusen/dev-cert-authority/commit/2de162a9bec37f744fa653b4c62c470a8c84fbed is included as well, with extras from @danwashusen .
